### PR TITLE
Fix include/preprocessor issues when building on Windows

### DIFF
--- a/Source/Plugins/TCPInterface.cpp
+++ b/Source/Plugins/TCPInterface.cpp
@@ -22,7 +22,7 @@
 #include "TCPInterface.h"
 #ifdef _WIN32
 typedef int socklen_t;
-#include "WSAStartupSingleton.h"
+#include "../WSAStartupSingleton.h"
 #else
 #include <sys/time.h>
 #include <unistd.h>

--- a/Source/Plugins/UDPForwarder.cpp
+++ b/Source/Plugins/UDPForwarder.cpp
@@ -550,7 +550,12 @@ namespace RakNet
                 RakSleep(0);
         }
         udpForwarder->threadRunning--;
-        return nullptr;
+
+#if (defined(_WIN32_WCE) || defined(_WIN32))
+		return 0;
+#else
+		return nullptr;
+#endif
     }
 } // namespace RakNet
 

--- a/Source/Plugins/UDPForwarder.cpp
+++ b/Source/Plugins/UDPForwarder.cpp
@@ -552,9 +552,9 @@ namespace RakNet
         udpForwarder->threadRunning--;
 
 #if (defined(_WIN32_WCE) || defined(_WIN32))
-		return 0;
+        return 0;
 #else
-		return nullptr;
+        return nullptr;
 #endif
     }
 } // namespace RakNet

--- a/Source/RakNetSocket2_Windows_Linux.cpp
+++ b/Source/RakNetSocket2_Windows_Linux.cpp
@@ -16,7 +16,9 @@
 
 #if !defined(__native_client__)
 
+#if (defined(__GNUC__)  || defined(__GCCXML__)) && !defined(__WIN32__)
 #include <netdb.h>
+#endif
 
 #if CRABNET_SUPPORT_IPV6==1
 


### PR DESCRIPTION
I was unable to build the project, so I made the following changes to the project:

TCPInterface.cpp:
- Fixed relative include directive for WSAStartupSingleton.h (it was one directory up).

UDPForwarder.cpp:
- RAK_THREAD_DECLARATION expands out to a function signature that returns an unsigned/DWORD on Windows systems, and otherwise a void*. I changed the return value to reflect this change (returns 0 or nullptr).

RakNetSocket2_Windows_Linux.cpp:
- Added missing preprocessor conditional. I'm not 100% sure on this change, but further down in the file is a similar block of code with this conditional, so I added it here. To me it makes sense since there's no netdb.h include on Windows, it's all in winsock2.h.

With all these changes I was able to build the project on MSVC 15 2017.

I looked through the open and closed issues and did not see anything addressing these problems.

I apologize if this pull request was made in error.