### PR TITLE
Add missing `#include <cstdint>` in _FindFirst.h

### DIFF
--- a/Source/Utils/_FindFirst.h
+++ b/Source/Utils/_FindFirst.h
@@ -10,6 +10,7 @@
 
 #include <dirent.h>
 #include <string>
+#include <cstdint>
 
 #define _A_NORMAL         0x00         // Normal file
 #define _A_RDONLY         0x01         // Read-only file


### PR DESCRIPTION
Fixes builds with GCC 13.

See <https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes>

Closes #17.